### PR TITLE
Fix using `kubectl logs`, caused by kubelet IP misdetection

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -63,5 +63,12 @@ sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://pack
 echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 sudo apt-get update -y
-
 sudo apt-get install -y kubelet=$KUBERNETES_VERSION kubectl=$KUBERNETES_VERSION kubeadm=$KUBERNETES_VERSION
+
+sudo apt-get update -y
+sudo apt-get install -y jq
+
+local_ip="$(ip --json a s | jq -r '.[] | if .ifname == "eth1" then .addr_info[] | if .family == "inet" then .local else empty end else empty end')"
+cat > /etc/default/kubelet << EOF
+KUBELET_EXTRA_ARGS=--node-ip=$local_ip
+EOF


### PR DESCRIPTION
When creating the cluster, I cannot do `kubectl logs`. The fix is described [here](https://github.com/kubernetes/kubernetes/issues/60835#issuecomment-395931644).